### PR TITLE
Optionally create a comment with diff on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ jobs:
         uses: diamorafaela/track-overrides@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          post-comment: false
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   github-token:
     description: "GitHub Token"
     required: true
+  post-comment:
+    description: 'Flag to indicate whether to post a comment on the PR (default: true)'
+    required: false
+    default: 'true'
 branding:
   icon: alert-circle
   color: blue
@@ -28,18 +32,21 @@ runs:
           changed_methods=$(python ${{ github.action_path }}/src/track_overrides.py ${{ github.workspace }})
           echo "::set-output name=changed_methods::${changed_methods}"
           if [[ -n "$changed_methods" ]]; then
+            echo "Override methods have changed in the upstream repository."
+            echo "Changed methods: $changed_methods"
             echo "::set-output name=has_changes::true"
           else
             echo "::set-output name=has_changes::false"
           fi
     
     - name: Post comment on PR if overrides changed
-      if: steps.track_overrides.outputs.has_changes == 'true'
+      if: steps.track_overrides.outputs.has_changes == 'true' && inputs.post-comment == 'true'
       uses: actions/github-script@v6
       env:
         DATA: ${{ steps.track_overrides.outputs.changed_methods }}
       with:
         github-token: ${{ inputs.github-token }}
+        post-comment: ${{ inputs.post-comment }}
         script: |
           const changedMethods = process.env.DATA;
           const commentBody = "The following override methods have changed in the upstream repository:\n\n" + changedMethods;

--- a/action.yml
+++ b/action.yml
@@ -20,17 +20,43 @@ runs:
 
     - name: Run override comparison
       shell: bash
-      id: check_overrides
+      id: track_overrides
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
           set -e 
           changed_methods=$(python ${{ github.action_path }}/src/track_overrides.py ${{ github.workspace }})
+          echo "::set-output name=changed_methods::${changed_methods}"
           if [[ -n "$changed_methods" ]]; then
-            echo "Override comparison result: $changed_methods"
-            exit 1
+            echo "::set-output name=has_changes::true"
           else
-            echo "No outdated overrides detected."
+            echo "::set-output name=has_changes::false"
           fi
     
+    - name: Post comment on PR if overrides changed
+      if: steps.track_overrides.outputs.has_changes == 'true'
+      uses: actions/github-script@v6
+      env:
+        DATA: ${{ steps.track_overrides.outputs.changed_methods }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const changedMethods = process.env.DATA;
+          const commentBody = "The following override methods have changed in the upstream repository:\n\n" + changedMethods;
+          github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body: commentBody
+          });
+
+    - name: Fail if overrides changed
+      shell: bash
+      if: steps.track_overrides.outputs.has_changes == 'true'
+      run: |
+        echo "Override methods have changed in the upstream repository."
+        exit 1
+
     - name: Cleanup
       if: always()
       shell: bash

--- a/src/track_overrides.py
+++ b/src/track_overrides.py
@@ -41,7 +41,7 @@ def compare_commit_hashes(directory):
                     method_name = match.group(4)
                     latest_commit_hash = get_last_commit_hash_for_file_in_branch(repo, file_path)
                     if latest_commit_hash and latest_commit_hash != commit_hash:
-                        changed_methods.append(f"Override method '{method_name}' in file '{file_path}' has changed in the upstream repository.")
+                        changed_methods.append(f"- `{method_name}` in file `{file_path}`.")
     return changed_methods
 
 


### PR DESCRIPTION
#1 

Added a `post-comment` option (default true)

![Captura de pantalla 2024-06-05 a la(s) 9 15 27 a  m](https://github.com/diamorafaela/track-overrides/assets/4945122/c2843026-66cf-4cab-9fc8-1f23e9324541)
